### PR TITLE
Improvement of logging connection errors and assume 

### DIFF
--- a/nefit.py
+++ b/nefit.py
@@ -99,6 +99,8 @@ class NefitThermostat(ClimateDevice):
     def update(self):
         """Get latest data"""
         _LOGGER.debug("update called.")
+        errors = []
+
         try:
             data = self._client.get_status()
             _LOGGER.debug("update finished. result={}".format(data))
@@ -115,50 +117,53 @@ class NefitThermostat(ClimateDevice):
             self._attributes["boiler_indicator"] = self._data.get("boiler indicator")
             self._attributes["control"] = self._data.get("control")
         except:
-            _LOGGER.error('Unkown error: Nefit api (get_status) returned invalid data')
+            errors.append('get_status')
 
         try:
             r = self._client.get_year_total()
             self._attributes["year_total"] = r.get("value")
             self._attributes["year_total_unit_of_measure"] = r.get("unitOfMeasure")
         except:
-            _LOGGER.error('Unkown error: Nefit api (get_year_total) returned invalid data')
+            errors.append('get_year_total')
 
         try:
             r = self._client.get("/ecus/rrc/userprogram/activeprogram")
             self._attributes["active_program"] = r.get("value")
         except:
-            _LOGGER.error('Unkown error: Nefit api (active_program) returned invalid data')
+            errors.append('active_program')
 
         try:
             r = self._client.get("/ecus/rrc/dayassunday/day10/active")
             self._attributes["today_as_sunday"] = (r.get("value") == "on")
         except:
-            _LOGGER.error('Unkown error: Nefit api (today_as_sunday) returned invalid data')
+            errors.append('today_as_sunday')
 
         try:
             r = self._client.get("/ecus/rrc/dayassunday/day11/active")
             self._attributes["tomorrow_as_sunday"] = (r.get("value") == "on")
         except:
-            _LOGGER.error('Unkown error: Nefit api (tomorrow_as_sunday) returned invalid data')
+            errors.append('tomorrow_as_sunday')
 
         try:
             r = self._client.get("/system/appliance/systemPressure")
             self._attributes["system_pressure"] = r.get("value")
         except:
-            _LOGGER.error('Unkown error: Nefit api (system_pressure) returned invalid data')
+            errors.append('system_pressure')
 
         try:
             r = self._client.get("/heatingCircuits/hc1/actualSupplyTemperature")
             self._attributes["supply_temp"] = r.get("value")
         except:
-            _LOGGER.error('Unkown error: Nefit api (supply_temp) returned invalid data')
+            errors.append('supply_temp')
 
         try:
             r = self._client.get("/system/sensors/temperatures/outdoor_t1")
             self._attributes["outside_temp"] = r.get("value")
         except:
-            _LOGGER.error('Unkown error: Nefit api (outside_temp) returned invalid data')
+            errors.append('outside_temp')
+
+        if len(errors) > 0:
+            _LOGGER.warning('Nefit api returned invalid data for: {}'.format(','.join(errors)))
 
     @property
     def current_temperature(self):


### PR DESCRIPTION
2 changes:
**Directly update new temperature to HA instead of waiting for the server** 
Now when you change the temperature, it sometimes happens that the nefit server is not fast enough and HA gets the "old" target temperature, instead of the newly updated one. Now, it is assumed that the just updated (new) target temperature is the correct temperature for the first update after the target temperature has changed.

**Combine log api errors and degrade to warning** 
It was a pain in my eyes that there were so many errors in the log. I combined them now and set it as a warning instead of error.