### PR TITLE
Added displayCode and uiStatus

### DIFF
--- a/nefit.py
+++ b/nefit.py
@@ -141,6 +141,12 @@ class NefitThermostat(ClimateDevice):
 
             r = self._client.get("/system/sensors/temperatures/outdoor_t1")
             self._attributes["outside_temp"] = r.get("value")
+
+            r = self._client.get("/system/appliance/displaycode")
+            self._attributes["displaycode"] = r.get("value")
+
+            r = self._client.get("/ecus/rrc/uiStatus")
+            self._attributes["uiStatus"] = r.get("value")
         except Exception as e:
             _LOGGER.warning('Nefit api returned invalid data: {}'.format(e))
             


### PR DESCRIPTION
With these two attributes and a some template sensors like below, more information can be obtained.

```
sensor:
   -platform: template
    sensors:
      nefit_boiler_status:
        value_template: '{%- if states.climate.nefit.attributes.uiStatus.BAI == "No" %}
          Off
        {% elif states.climate.nefit.attributes.uiStatus.BAI == "CH" %}
          Central heating
        {% elif states.climate.nefit.attributes.uiStatus.BAI == "HW" %}
          Hot water
        {% else %}
          Unknown
        {%- endif %}'
        friendly_name: 'Boiler status'
        entity_id: climate.nefit
      nefit_display_code:
        value_template: '{%- if states.climate.nefit.attributes.displaycode == "-H" %}
          central heating active
        {% elif states.climate.nefit.attributes.displaycode == "=H" %}
          hot water active
      	{% elif states.climate.nefit.attributes.displaycode == "0C" %}
	      	system starting
	    	{% elif states.climate.nefit.attributes.displaycode == "0L" %}
      		system starting
	    	{% elif states.climate.nefit.attributes.displaycode == "0U" %}
	      	system starting
      	{% elif states.climate.nefit.attributes.displaycode == "0E" %}
      		system waiting
      	{% elif states.climate.nefit.attributes.displaycode == "0H" %}
      		system standby
      	{% elif states.climate.nefit.attributes.displaycode == "0A" %}
      		system waiting (boiler cannot transfer heat to central heating)
      	{% elif states.climate.nefit.attributes.displaycode == "0Y" %}
      		system waiting (boiler cannot transfer heat to central heating
      	{% elif states.climate.nefit.attributes.displaycode == "2E" %}
      		boiler water pressure too low
      	{% elif states.climate.nefit.attributes.displaycode == "H07" %}
	      	boiler water pressure too low
	      {% elif states.climate.nefit.attributes.displaycode == "2F" %}
      		sensors measured abnormal temperature
      	{% elif states.climate.nefit.attributes.displaycode == "2L" %}
      		sensors measured abnormal temperature
      	{% elif states.climate.nefit.attributes.displaycode == "2P" %}
      		sensors measured abnormal temperature
      	{% elif states.climate.nefit.attributes.displaycode == "2U" %}
      		sensors measured abnormal temperature
      	{% elif states.climate.nefit.attributes.displaycode == "4F" %}
      		sensors measured abnormal temperature
      	{% elif states.climate.nefit.attributes.displaycode == "4L" %}
      		sensors measured abnormal temperature
      	{% elif states.climate.nefit.attributes.displaycode == "6A" %}
      		burner doesn''t ignite
      	{% elif states.climate.nefit.attributes.displaycode == "6C" %}
      		burner doesn''t ignite
      	{% elif states.climate.nefit.attributes.displaycode == "rE" %}
      		system restarting
        {% else %}
          Unknown
        {%- endif %}'
        friendly_name: 'Display code'
        entity_id: climate.nefit
```